### PR TITLE
Fix injecting custom request header in beforeRequest hook

### DIFF
--- a/.manifest.json
+++ b/.manifest.json
@@ -1,6 +1,6 @@
 {
   "liblabVersion": "2.1.31",
-  "date": "2024-09-05T21:54:58.569Z",
+  "date": "2024-09-06T00:38:54.512Z",
   "config": {
     "apiId": 1126,
     "sdkName": "salad-cloud-imds-sdk",
@@ -155,7 +155,7 @@
     },
     "multiTenant": true,
     "hooksLocation": {
-      "bucketKey": "7017/hooks.zip",
+      "bucketKey": "7019/hooks.zip",
       "bucketName": "prod-liblab-api-stack-hooks"
     },
     "includeWatermark": false,

--- a/src/http/hooks/custom-hook.ts
+++ b/src/http/hooks/custom-hook.ts
@@ -5,10 +5,10 @@ import { HttpRequest, HttpResponse, HttpError } from './hook';
 export class CustomHook implements Hook {
   public async beforeRequest(request: HttpRequest, params: Map<string, string>): Promise<HttpRequest> {
     if (request.headers == null) {
-      request.headers = {};
+      request.headers = new Map<string, unknown>();
     }
 
-    request.headers['Metadata'] = 'true';
+    request.headers.set('Metadata', 'true');
     return request;
   }
 


### PR DESCRIPTION
The request headers are typed as a Map, not a generic object. This fixes injecting the custom `Metadata: true` request header in the `beforeRequest` hook.